### PR TITLE
Add Obsoletes: gnupg < 1.4.23-3

### DIFF
--- a/gnupg1.spec
+++ b/gnupg1.spec
@@ -22,6 +22,7 @@ BuildRequires: libusb-devel
 %endif
 # pgp-tools, perl-GnuPG-Interface include 'Requires: gpg' -- Rex
 Provides: gpg1 = %{version}-%{release}
+Obsoletes: gnupg < 1.4.23-3
 
 %description
 GnuPG (GNU Privacy Guard) is a GNU utility for encrypting data and


### PR DESCRIPTION
I think we also need to add this.
Additionally gnupg2 needs to remove the conditional around its Provides: gnupg and needs to update the version number.

Also, when trying to update to gnupg1 I see docker depends on it, we need to make sure it can work with gnupg2 installed.
